### PR TITLE
Duplicate slugs with STI models

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -125,7 +125,11 @@ module Mongoid #:nodoc:
         metadata = reflect_on_all_associations(:embedded_in).first
         _parent.send(metadata.inverse_of)
       else
-        self.class
+        appropriate_class = self.class
+        while (appropriate_class.superclass.include?(Mongoid::Document))
+          appropriate_class = appropriate_class.superclass
+        end
+        appropriate_class
       end
     end
   end

--- a/spec/models/comic_book.rb
+++ b/spec/models/comic_book.rb
@@ -1,0 +1,3 @@
+class ComicBook < Book
+  
+end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -287,5 +287,13 @@ module Mongoid
         Person.collection.index_information.should_not have_key "permalink_1"
       end
     end
+    
+    context "when the object is STI" do
+      it "should take STI and non STI objects as the same slug-type" do
+        book = Book.create(:title => "Anti Oedipus")
+        comic_book = ComicBook.create(:title => "Anti Oedipus")
+        comic_book.slug.should_not eql(book.title)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello,

With STI models, the scope generated depends of the model's class.
Therefore, if there are two objects with equivalent slugs, we'll have a duplicate slug error because the two objects are in the same collection but, because of the STI, the request checks only a part of it.

Wich that patch, the scope is always done on the highest class possible. So all the objects in the collection are taken into account, fixing that problem of duplicated slugs in STI.
