### PR TITLE
Two changes

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -26,7 +26,7 @@ module Mongoid #:nodoc:
 
         self.slug_name      = options[:as] || :slug
         self.slug_scope     = options[:scope] || nil
-        self.first_valid    = options[:first_valid] || false
+        self.first_valid    = options[:any] || false
         self.slugged_fields = fields
 
         if options[:scoped]
@@ -53,13 +53,6 @@ module Mongoid #:nodoc:
         instance_eval <<-CODE
           def self.find_by_#{slug_name}(slug)
             where(slug_name => slug).first rescue nil
-          end
-          
-          def self.find_by_#{slug_name}_or_id(value)
-            result = find_by_#{slug_name}(value)
-            result = find(value) unless result
-
-            result
           end
         CODE
       end

--- a/spec/models/article.rb
+++ b/spec/models/article.rb
@@ -1,0 +1,7 @@
+class Article
+  include Mongoid::Document
+  include Mongoid::Slug
+  field :brief
+  field :title
+  slug  :title, :brief, :any => true
+end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -129,7 +129,7 @@ module Mongoid
           :first_name => "Gilles",
           :last_name  => "Deleuze")
       end
-
+      
       it "generates a slug" do
         author.to_param.should eql "gilles-deleuze"
       end
@@ -156,6 +156,26 @@ module Mongoid
 
       it "finds by slug" do
         Author.find_by_slug("gilles-deleuze").should eql author
+      end
+
+    end
+    
+    context "when :any is passed as an argument" do
+      let!(:article) do
+        Article.create(
+          :brief => "This is the brief",
+          :title => "This is the title")
+      end
+      
+      it "uses the first available field for the slug if any option is used" do
+        article.to_param.should eql 'this-is-the-title'
+        article.title = ""
+        article.save
+        article.to_param.should eql 'this-is-the-brief'
+        
+        article.title = nil
+        article.save
+        article.to_param.should eql 'this-is-the-brief'
       end
     end
 


### PR DESCRIPTION
1) added a find_by_#{slug_name}_or_id : self-explanatory

2) added a "first_value" option (might need a better name).  with this option if you pass multiple fields to your slug it looks for the first one that has a value and uses that.
