### PR TITLE
Fix for when inverse_of is not specified

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -132,8 +132,8 @@ module Mongoid #:nodoc:
         inverse = metadata.inverse_of || collection_name
         parent.respond_to?(inverse) ? parent.send(inverse) : self.class
       elsif embedded?
-        metadata = reflect_on_all_associations(:embedded_in).first
-        _parent.send(metadata.inverse_of)
+        parent_metadata = reflect_on_all_associations(:embedded_in).first
+        _parent.send(parent_metadata.inverse_of || self.metadata.name)
       else
         appropriate_class = self.class
         while (appropriate_class.superclass.include?(Mongoid::Document))

--- a/spec/models/partner.rb
+++ b/spec/models/partner.rb
@@ -3,5 +3,5 @@ class Partner
   include Mongoid::Slug
   field :name
   slug  :name
-  embedded_in :relationship, :inverse_of => :partners
+  embedded_in :relationship
 end

--- a/spec/models/relationship.rb
+++ b/spec/models/relationship.rb
@@ -4,5 +4,5 @@ class Relationship
   field :name
   slug  :name
   embeds_many :partners
-  embedded_in :person, :inverse_of => :relationships
+  embedded_in :person
 end

--- a/spec/models/subject.rb
+++ b/spec/models/subject.rb
@@ -3,5 +3,5 @@ class Subject
   include Mongoid::Slug
   field :name
   slug  :name
-  embedded_in :book, :inverse_of => :subjects
+  embedded_in :book
 end


### PR DESCRIPTION
Greeting,

It seems the inverse_of option is no longer required on any mongoid relation (http://mongoid.org/docs/upgrading).  This patch uses mongoid's improved metadata to infer the name of the parent relation when inverse_of is not supplied.

Peter
