### PR TITLE
fixing a bug with generating unique slugs

### DIFF
--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -19,8 +19,10 @@ module Mongoid
       end
 
       it "generates a unique slug by appending a counter to duplicate text" do
-        dup = Book.create(:title => book.title)
-        dup.to_param.should eql "a-thousand-plateaus-1"
+        15.times{ |x|
+          dup = Book.create(:title => book.title)
+          dup.to_param.should eql "a-thousand-plateaus-#{x+1}"
+        }
       end
 
       it "does not update slug if slugged fields have not changed" do


### PR DESCRIPTION
Hi, this patch fixes a bug where after slugname-10, the next generated slug would still be slugname-10.  

The existing slugs were being sorted alphabetically, and thus mongoid-slug thought that slugname-9 was the highest value, and would try to generate slugname-10.

thanks!
jean
