### PR TITLE
Use slug_size to overcome alphabetically sorted order

### DIFF
--- a/lib/mongoid/slug/railtie.rb
+++ b/lib/mongoid/slug/railtie.rb
@@ -1,0 +1,11 @@
+module Rails #:nodoc:
+  module Mongoid #:nodoc:
+    module Slug #:nodoc:
+      class Railtie < Rails::Railtie #:nodoc:
+        rake_tasks do
+          load 'mongoid/slug/railties/database.rake'
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/slug/railties/database.rake
+++ b/lib/mongoid/slug/railties/database.rake
@@ -1,0 +1,6 @@
+namespace :slug do
+  desc 'Re-calculate slug_size and update to database'
+  task :update_slug_size, :model, :needs => :environment do |t, args|
+    args[:model].singularize.classify.constantize.update_slug_size
+  end
+end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -297,20 +297,20 @@ module Mongoid
 
       it "defines an index on the slug in top-level objects" do
         Book.create_indexes
-        Book.collection.index_information.should have_key "slug_1"
+        Book.collection.index_information.should have_key "slug_-1_slug_size_-1"
       end
 
       context "when slug is scoped by a reference association" do
         it "defines a non-unique index" do
           Author.create_indexes
-          Author.index_information["slug_1"]["unique"].should be_false
+          Author.index_information["slug_-1_slug_size_-1"]["unique"].should be_false
         end
       end
 
       context "when slug is not scoped by a reference association" do
         it "defines a unique index" do
           Book.create_indexes
-          Book.index_information["slug_1"]["unique"].should be_true
+          Book.index_information["slug_-1_slug_size_-1"]["unique"].should be_true
         end
       end
     end


### PR DESCRIPTION
I have a diff solution for https://github.com/papercavalier/mongoid-slug/pull/23 by introducing slug_size. In Rails, run "rake slug:update_slug_size[model]" to init slug_size for existing docs.
