### PR TITLE
I couldn't run specs after a bundle install / rspec spec, this fixes it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source :rubygems
 gemspec
 
+gem 'mongoid', '~> 2.0'
+gem 'bson_ext', '~> 1.3'
 gem 'database_cleaner', '~> 0.6.0'
-gem 'rspec', '~> 2.5.0'
+gem 'rspec', '~> 2.6.0'

--- a/spec/models/comic_book.rb
+++ b/spec/models/comic_book.rb
@@ -1,2 +1,4 @@
+require 'models/book'
+
 class ComicBook < Book
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ require "mongoid"
 require "stringex"
 require "rspec"
 
+require 'yaml' 
+
+YAML::ENGINE.yamler = 'syck' 
+
 Mongoid.configure do |config|
   name = "mongoid_slug_test"
   config.master = Mongo::Connection.new.db(name)
@@ -15,7 +19,7 @@ require File.expand_path("../../lib/mongoid/slug", __FILE__)
 
 Dir["#{File.dirname(__FILE__)}/models/*.rb"].each { |f| require f }
 
-Rspec.configure do |c|
+RSpec.configure do |c|
   c.before(:all)  { DatabaseCleaner.strategy = :truncation }
   c.before(:each) { DatabaseCleaner.clean }
 end


### PR DESCRIPTION
On a clean Linux setup I was getting the usual warning of bson_ext missing, an include problem between comic_book and book, then a YAML error. All trivial fixes.
