### PR TITLE
Allow overriding of slug at model creation time

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -159,7 +159,9 @@ module Mongoid #:nodoc:
     end
 
     def generate_slug
-      if new_record? || slugged_fields_changed?
+      # Generate a slug for new records only if the slug was not set.  If we're not a new record
+      # generate a slug if our slugged fields changed on us.
+      if (new_record? && !read_attribute(slug_name)) || (!new_record? && slugged_fields_changed?)
         generate_slug!
       end
     end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -386,5 +386,12 @@ module Mongoid
         book.reload.slug.should eql "proust-and-signs"
       end
     end
+    
+    context "when the slugged field is set upon creation" do
+      it "respects the provided slug and does not generate a new one" do
+        book = Book.create(:title => "A Thousand Plateaus", :slug => 'not-what-you-expected')
+        book.to_param.should eql "not-what-you-expected"
+      end
+    end
   end
 end


### PR DESCRIPTION
This small patch just makes it so you can do the following:

``` ruby
Book.create(:title => 'A Title', :slug => 'a-different-slug')
```
