### PR TITLE
Allow define slug on aliased field

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -77,7 +77,7 @@ module Mongoid #:nodoc:
             block
           else
             lambda do |doc|
-              slugged_fields.map { |f| doc.read_attribute(f) }.
+              slugged_fields.map { |f| doc.send(f) }.
                              join(' ')
             end
           end

--- a/spec/models/alias.rb
+++ b/spec/models/alias.rb
@@ -1,0 +1,6 @@
+class Alias
+  include Mongoid::Document
+  include Mongoid::Slug
+  field :name, :as => :author_name
+  slug  :author_name
+end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -349,6 +349,13 @@ module Mongoid
       end
     end
 
+    context "when slug defined on alias of field" do
+      it "should use accessor, not alias" do
+        pseudonim  = Alias.create(:author_name => 'Max Stirner')
+        pseudonim.slug.should eql('max-stirner')
+      end
+    end
+
     describe ".find_by_slug" do
       let!(:book) { Book.create(:title => "A Thousand Plateaus") }
 


### PR DESCRIPTION
Permit to use plugin with MongoID syntax (undocumented):
field :n, :as => :long_human_readable_name
