### PR TITLE
Add multi index on scoped slugs.

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -79,7 +79,11 @@ module Mongoid
         end
 
         if options[:index]
-          index slug_name, :unique => !slug_scope
+          if slug_scope
+            index [[slug_name, Mongo::ASCENDING], [slug_scope, Mongo::ASCENDING]], :unique => true
+          else
+            index slug_name, :unique => true
+          end
           index slug_history_name if slug_history_name
         end
 

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -371,22 +371,27 @@ module Mongoid
         Author.collection.drop_indexes
       end
 
-      it "defines an index on the slug in top-level objects" do
-        Book.create_indexes
-        Book.collection.index_information.should have_key "slug_1"
-      end
-
-      context "when slug is scoped by a reference association" do
-        it "defines a non-unique index" do
-          Author.create_indexes
-          Author.index_information["slug_1"]["unique"].should be_false
-        end
-      end
-
       context "when slug is not scoped by a reference association" do
+        it "defines an index on the slug" do
+          Book.create_indexes
+          Book.collection.index_information.should have_key "slug_1"
+        end
+
         it "defines a unique index" do
           Book.create_indexes
           Book.index_information["slug_1"]["unique"].should be_true
+        end
+      end
+
+      context "when slug is scoped by a reference association" do
+        it "defines an index on the slug and the scope" do
+          Author.create_indexes
+          Author.collection.index_information.should have_key "slug_1_book_1"
+        end
+
+        it "defines a unique index" do
+          Author.create_indexes
+          Author.index_information["slug_1_book_1"]["unique"].should be_true
         end
       end
     end


### PR DESCRIPTION
I think it's really important that scoped slugs are indexed with a multiple field index, for various reasons, so I made the modification.
Indexes are now also always unique, and for a slug I think it's quite logical !

The test suite has been updated in consequence.
