### PR TITLE
Do not generate incremented slug when similar slugs exist if existing slug is still unique.

### DIFF
--- a/spec/models/publisher.rb
+++ b/spec/models/publisher.rb
@@ -1,0 +1,9 @@
+class Publisher
+  include Mongoid::Document
+  include Mongoid::Slug
+  field :login
+  field :name
+  slug  :login, :name do |doc|
+    [doc.title, doc.brief].reject(&:blank?).first
+  end
+end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -491,7 +491,7 @@ module Mongoid
       end
     end
 
-    describe ".for_unique_slug_for" do
+    describe ".find_unique_slug_for" do
       it "returns the unique slug" do
         Book.find_unique_slug_for("A Thousand Plateaus").should eq("a-thousand-plateaus")
       end
@@ -504,6 +504,13 @@ module Mongoid
       it "returns the unique slug as if it were the provided object" do
         book = Book.create(:title => "A Thousand Plateaus")
         Book.find_unique_slug_for("A Thousand Plateaus", :model => book).should eq("a-thousand-plateaus")
+      end
+      
+      it "returns the unique slug as if it where the provided object even if there are other similar slugs" do
+        book = Book.create(:title => "A Thousand Plateaus")
+        Book.create(:title => "A Thousand Plateaus") # This generates a slug of 'a-thousand-plateaus-2' correctly.
+        # This should still give us back 'a-thousand-plateaus'
+        Book.find_unique_slug_for(book.slug, :model => book).should eq("a-thousand-plateaus")
       end
     end
 


### PR DESCRIPTION
Ensure that we do not generate a new incremented slug for a document simply because there are other similar slugs.
