### PR TITLE
Control slug generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ Friend.find_by_slug('admin') # => nil
 friend.slug # => 'admin-1'
 ```
 
+Control When Slugs Are Generated
+--------------------------------
+
+To control when a slug is generated, override the `generate_slug?` method in your model.
+
+For example, to generate slugs only for active projects:
+
+```ruby
+class Project
+  include Mongoid::Document
+  include Mongoid::Slug
+
+  field :name,    :type => String
+  field :active,  :type => Boolean, :default => false
+
+  slug :name
+
+  def generate_slug?
+    active?
+  end
+end
+```
+
 [1]: https://github.com/rsl/stringex/
 [2]: https://secure.travis-ci.org/hakanensari/mongoid-slug.png
 [3]: http://travis-ci.org/hakanensari/mongoid-slug

--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -309,7 +309,7 @@ module Mongoid
 
     # @return [Boolean] Whether the slug requires to be rebuilt
     def slug_should_be_rebuilt?
-      new_record? or slug_changed? or slugged_attributes_changed?
+      (new_record? || slug_changed? || slugged_attributes_changed?) && generate_slug?
     end
 
     unless self.respond_to? :slug
@@ -328,6 +328,31 @@ module Mongoid
 
     def slugged_attributes_changed?
       slugged_attributes.any? { |f| attribute_changed? f }
+    end
+
+    # Determines whether or not a slug should be generated.
+    #
+    # Override this method in your model to control when a slug is generated.
+    #
+    # @return [Boolean] Whether or not the slug should be generated.
+    #
+    # @example Generate a slug for active projects.
+    #   class Project
+    #     include Mongoid::Document
+    #     include Mongoid::Slug
+    #
+    #     field :name,    :type => String
+    #     field :active,  :type => Boolean, :default => false
+    #
+    #     slug :name
+    #
+    #     def generate_slug?
+    #       active?
+    #     end
+    #   end
+    #
+    def generate_slug?
+      true
     end
 
     # @return [String] A string which Action Pack uses for constructing an URL

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -36,6 +36,33 @@ module Mongoid
         book.to_param.should eql "a-thousand-plateaus"
       end
 
+      context "when #generate_slug? returns false" do
+        let(:book) do
+          b = Book.new(:title => "A Thousand Plateaus")
+
+          b.instance_eval do
+            def generate_slug?
+              false
+            end
+          end
+
+          b.save
+          b
+        end
+
+        it "does not set slug" do
+          book.slug.should be nil
+        end
+
+        it "does not update slug" do
+          original_slug = "the-original-slug"
+          book.slug = original_slug
+          book.title = "Anti Oedipus"
+          book.save
+          book.slug.should == original_slug
+        end
+      end
+
       it "finds by slug" do
         Book.find_by_slug(book.to_param).should eql book
       end
@@ -681,7 +708,7 @@ module Mongoid
       end
     end
 
-    describe ".find_unique_slug_for" do
+    describe ".for_unique_slug_for" do
       it "returns the unique slug" do
         Book.find_unique_slug_for("A Thousand Plateaus").should eq("a-thousand-plateaus")
       end


### PR DESCRIPTION
At the moment, models that define a slug always generate a slug. Sometimes, it's desirable not to generate a slug.

This pull request enables users to control whether or not a slug is generated.
