### PR TITLE
Be a bit tidier in how we generate the callbacks

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -313,11 +313,7 @@ module Mongoid
 
     # @return [Boolean] Whether the slug requires to be rebuilt
     def slug_should_be_rebuilt?
-      slug_changed? || slugged_attributes_changed?
-    end
-
-    def slugged_attributes_changed?
-      slugged_attributes.any? { |f| attribute_changed? f.to_s }
+      slug_changed? || slugged_attributes.any? { |f| attribute_changed? f.to_s }
     end
 
     # @return [String] A string which Action Pack uses for constructing an URL


### PR DESCRIPTION
I'm doing some callback wrangling elsewhere and it would be nicer if mongoid-slug were to generate the callback using symbols.

Using the minimal callback in the :permanent case was an after-thought, but I think legit.
