### PR TITLE
Fixed slugged_attributes_changed method to work with aliased fields.

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -316,7 +316,7 @@ module Mongoid
     end
 
     def slugged_attributes_changed?
-      slugged_attributes.any? { |f| attribute_changed? f.to_s }
+      slugged_attributes.any? { |f| self.send :"#{f}_changed?" }
     end
 
     # @return [String] A string which Action Pack uses for constructing an URL


### PR DESCRIPTION
Just a point out that `attribute_changed?` method doesn't work with aliased fields.
Rails 3.2.5 console for example:

``` ruby
1.9.3p194 :003 > p.title = 'TEST'
 => "TEST" 
1.9.3p194 :004 > p.send :slugged_attributes_changed?
 => false 
1.9.3p194 :005 > p.slugged_attributes
 => ["title"] 
1.9.3p194 :008 > p.send :attribute_changed?, 'title'
 => false 
1.9.3p194 :009 > p.send :attribute_changed?, 'ti'
 => true 
1.9.3p194 :010 > p.send :title_changed?
 => true 

```
