### PR TITLE
Fix index when using a scope.

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -57,7 +57,8 @@ module Mongoid
         self.history            = options[:history]
 
         if slug_scope
-          index({slug_scope: 1, _slugs: 1}, {unique: true})
+          scope_key = (metadata = self.reflect_on_association(slug_scope)) ? metadata.key : slug_scope
+          index({scope_key => 1, _slugs: 1}, {unique: true})
         else
           index({_slugs: 1}, {unique: true})
         end


### PR DESCRIPTION
The old code was wrong for two reasons:
- `slug_scope: 1` != `slug_scope => 1`
- the index key shouldn't literally be `slug_scope` when it's referring to a relation. (`company` vs `company_id`)
