### PR TITLE
Allow for ObjectIds as the slug if it is the actual document id. (with spec)

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -173,8 +173,9 @@ module Mongoid
         existing_history_slugs.push(*history_slugs.first(history_slugs.length() -1).find_all { |cur_slug| cur_slug =~ pattern })
       end
 
-      #do not allow a slug that can be interpreted as the current document id
-      existing_slugs << _slug unless self.class.look_like_slugs?([_slug])
+      # do not allow a slug that can be interpreted as the current document id
+      # unless it is the current document id which will work with either find
+      existing_slugs << _slug if !self.class.look_like_slugs?([_slug]) && _slug != self._id.to_s
 
       #make sure that the slug is not equal to a reserved word
       if reserved_words.any? { |word| word === _slug }

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -29,6 +29,12 @@ module Mongoid
         bad = Book.create(:title => "4ea0389f0364313d79104fb3")
         bad.slugs.should_not include("4ea0389f0364313d79104fb3")
       end
+      
+      it "does allow a Moped::BSON::ObjectId as use for a slug if it is the document id" do
+        book = Book.create()
+        book.update_attributes(:title => book.id.to_s)
+        book.slugs.should include(book.id.to_s)
+      end
 
       it "does not update slug if slugged fields have not changed" do
         book.save


### PR DESCRIPTION
...ocument's id.  This way either a regular find or a find_by_slug will succeed
