### PR TITLE
fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,4 +231,4 @@ unique = Mongoid::Slug::UniqueSlug.new(Book.new).find_unique(title)
 [1]: https://github.com/rsl/stringex/
 [2]: https://secure.travis-ci.org/hakanensari/mongoid-slug.png
 [3]: http://travis-ci.org/hakanensari/mongoid-slug
-[4]: https://github.com/hakanensari/mongoid-slug/blob/master/lib/mongoid/slug.rb
+[4]: https://github.com/digitalplaywright/mongoid-slug/blob/master/lib/mongoid/slug.rb


### PR DESCRIPTION
Now pointing to the canonical repo's `slug.rb` file.
