### PR TITLE
Fix localized slug creation when using history and when the locale changes after document is created

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -119,7 +119,7 @@ module Mongoid
     def build_slug
       _new_slug = find_unique_slug
       self._slugs.delete(_new_slug) if self._slugs
-      if !!self.history
+      if !!self.history && self._slugs.is_a?(Array)
         self._slugs << _new_slug
       else
         self._slugs = [_new_slug]

--- a/spec/models/page_slug_localized_history.rb
+++ b/spec/models/page_slug_localized_history.rb
@@ -1,0 +1,9 @@
+class PageSlugLocalizeHistory
+  include Mongoid::Document
+  include Mongoid::Slug
+  field :title, localize: true
+  field :content
+  field :order, :type => Integer
+  slug  :title, localize: true, history: true
+  default_scope asc(:order)
+end


### PR DESCRIPTION
When using slug history, if the locale is changed after the document creation, and we try to save the document again, an error is raised :

```
# NoMethodError: undefined method `<<' for nil:NilClass
#   from /path/to/lib/mongoid/slug.rb:123:in `build_slug'
```

This pull request fixes that by replacing `if !!self.history` by `if !!self.history && self._slugs.is_a?(Array)`
