### PR TITLE
Make uniqueness lookup "unscoped"

### DIFF
--- a/lib/mongoid/slug/criteria.rb
+++ b/lib/mongoid/slug/criteria.rb
@@ -84,9 +84,9 @@ module Mongoid
         if localized
           def_loc = I18n.default_locale
           query = { '$in' => slugs }
-          unscoped.where({'$or' => [{ _slugs: query }, { "_slugs.#{def_loc}" => query }]}).limit(slugs.length)
+          where({'$or' => [{ _slugs: query }, { "_slugs.#{def_loc}" => query }]}).limit(slugs.length)
         else
-          unscoped.where({ _slugs: { '$in' => slugs } }).limit(slugs.length)
+          where({ _slugs: { '$in' => slugs } }).limit(slugs.length)
         end
       end
 


### PR DESCRIPTION
This pull request ensures that the uniqueness check on `UniqueSlug` ignores any `default_scope` set on models, by using `unscoped`.

This fixes issues with duplicate keys, and allows Mongoid::Slug to work with Mongoid::Paranoia.

Closes #119
