### PR TITLE
Add no-dash option for duplicate slug

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -5,6 +5,7 @@ module Mongoid
 
     included do
       cattr_accessor :reserved_words,
+                     :no_dash,
                      :slug_scope,
                      :slugged_attributes,
                      :url_builder,
@@ -52,6 +53,7 @@ module Mongoid
 
         self.slug_scope            = options[:scope]
         self.reserved_words        = options[:reserve] || Set.new(["new", "edit"])
+        self.no_dash               = options[:no_dash] ? "" : "-"
         self.slugged_attributes    = fields.map &:to_s
         self.history               = options[:history]
         self.by_model_type         = options[:by_model_type]

--- a/lib/mongoid/slug/unique_slug.rb
+++ b/lib/mongoid/slug/unique_slug.rb
@@ -62,7 +62,7 @@ module Mongoid
       attr_reader :model, :_slug
 
       def_delegators :@model, :slug_scope, :reflect_on_association, :read_attribute,
-        :check_against_id, :reserved_words, :url_builder, :metadata,
+        :check_against_id, :reserved_words, :no_dash, :url_builder, :metadata,
         :collection_name, :embedded?, :reflect_on_all_associations, :by_model_type
 
       def initialize model
@@ -108,7 +108,7 @@ module Mongoid
         # - e.g if the slug 'foo-2' is taken, but 'foo' is available, the user can use 'foo'.
         if @state.slug_included?
           highest = @state.highest_existing_counter
-          @_slug += "-#{highest.succ}"
+          @_slug += "#{no_dash}#{highest.succ}"
         end
         _slug
       end

--- a/spec/models/no_dash_on_duplicate.rb
+++ b/spec/models/no_dash_on_duplicate.rb
@@ -1,0 +1,7 @@
+class NoDashOnDuplicate
+	include Mongoid::Document
+  include Mongoid::Slug
+  field :title
+
+	slug  :title, history: true, no_dash: true
+end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -1105,9 +1105,36 @@ module Mongoid
         ParanoidDocument.deleted.first.restore
         expect(ParanoidDocument.find(paranoid_doc.slug)).to eq(paranoid_doc)
       end
+    end
 
+    describe "When 'no_dash: true' option is used" do
 
+      let(:first_book) { NoDashOnDuplicate.create(title: 'Electronica') }
+      let(:second_book) { NoDashOnDuplicate.create(title: first_book.title) }
+      let(:reserved_title) { NoDashOnDuplicate.create(title: 'edit') }
 
+      it "generates a unique slug without a dash before the number" do
+        second_book.to_param.should eql "electronica1"
+      end
+
+      it "does not add a dash to the default reserved word" do
+        reserved_title.to_param.should eql 'edit1'
+      end
+
+      context "when history is set to true" do
+
+        before do
+          first_book.title = 'Electric'
+          first_book.save
+        end
+
+        it "generates a unique slug by appending a counter, with no dash, to duplicate title" do
+          dup = NoDashOnDuplicate.create(:title => "Electronica")
+          dup.to_param.should eql "electronica1"
+        end
+
+      end
+      
     end
   end
 end


### PR DESCRIPTION
My stab at issue https://github.com/digitalplaywright/mongoid-slug/issues/126

Which adds the option to use `no_dash: true`
So a duplicate of a slug 'electronica' would become 'electronica1'
