### PR TITLE
Don't use unique indexes with polymorphics

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -64,7 +64,7 @@ module Mongoid
             scope_key = (metadata = self.reflect_on_association(slug_scope)) ? metadata.key : slug_scope
             if options[:by_model_type] == true
               # Add _type to the index to fix polymorphism
-              index({ _type: 1, scope_key => 1, _slugs: 1}, {unique: true})
+              index({ _type: 1, scope_key => 1, _slugs: 1})
             else
               index({scope_key => 1, _slugs: 1}, {unique: true})
             end
@@ -72,7 +72,7 @@ module Mongoid
           else
             # Add _type to the index to fix polymorphism
             if options[:by_model_type] == true
-              index({_type: 1, _slugs: 1}, {unique: true})
+              index({_type: 1, _slugs: 1})
             else
               index({_slugs: 1}, {unique: true})
             end

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -544,7 +544,7 @@ module Mongoid
           end
 
           it "defines a unique index" do
-            BookPolymorphic.index_options[ :_type => 1, :_slugs => 1 ][:unique].should be_true
+            BookPolymorphic.index_options[ :_type => 1, :_slugs => 1 ][:unique].should_not be_true
           end
         end
 


### PR DESCRIPTION
With a mix of scoped and unscoped slugs, because the indexes are created on
the top-level class, you'll end up with `duplicate key error`s on the unscoped
index even when scoped slugs would be valid.

I can't think of a way to spec this, since mongoid_slug is otherwise doing the right thing, and the error will only be visible in safe mode.
