### PR TITLE
Add sparse option to slug index.

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -66,7 +66,7 @@ module Mongoid
               # Add _type to the index to fix polymorphism
               index({ _type: 1, scope_key => 1, _slugs: 1})
             else
-              index({scope_key => 1, _slugs: 1}, {unique: true})
+              index({scope_key => 1, _slugs: 1}, {unique: true, sparse: true})
             end
 
           else
@@ -74,7 +74,7 @@ module Mongoid
             if options[:by_model_type] == true
               index({_type: 1, _slugs: 1})
             else
-              index({_slugs: 1}, {unique: true})
+              index({_slugs: 1}, {unique: true, sparse: true})
             end
           end
         end


### PR DESCRIPTION
Without this option, db:mongoid:create_indexes fails because of multiple null values when user don't already have slugs.

```
rake aborted!
The operation: #<Moped::Protocol::Command
  @length=83
  @request_id=7
  @response_to=0
  @op_code=2004
  @flags=[]
  @full_collection_name="project_development.$cmd"
  @skip=0
  @limit=-1
  @selector={:getlasterror=>1, :w=>1}
  @fields=nil>
failed with error 11000: "E11000 duplicate key error index: project_development.users.$_slugs_1  dup key: { : null }"

See https://github.com/mongodb/mongo/blob/master/docs/errors.md
```

http://docs.mongodb.org/manual/core/index-unique/
