### PR TITLE
Mongoid4 also use Moped::BSON::ObjectId

### DIFF
--- a/lib/mongoid/slug/criteria.rb
+++ b/lib/mongoid/slug/criteria.rb
@@ -67,12 +67,11 @@ module Mongoid
 
       # a string will not look like a slug if it looks like a legal BSON::ObjectId
       def objectid_slug_strategy id
-        obj_id = if defined? BSON::ObjectId
-                   BSON::ObjectId
-                 else
-                   Moped::BSON::ObjectId
-                 end
-        obj_id.legal? id
+        if defined? BSON::ObjectId
+          BSON::ObjectId.legal? id
+        else
+          Moped::BSON::ObjectId.legal? id
+        end
       end
 
       # a string will always look like a slug


### PR DESCRIPTION
That conditional cause a `NameError: uninitialized constant Mongoid::Slug::Criteria::BSON` on Mongoid 4.
Tested with Mongoid 4.0.0
