### PR TITLE
Changes to Gemfile.mongoid4

### DIFF
--- a/Gemfile.mongoid4
+++ b/Gemfile.mongoid4
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'mongoid', '~> 4.0.0.beta1' 
-gem 'mongoid-paranoia', github: 'simi/mongoid-paranoia'
+gem 'mongoid', '~> 4.0.0'
+gem 'mongoid_paranoia'
 
 gemspec


### PR DESCRIPTION
- Mongoid 4 has been officially released
- simi/mongoid-paranoia is now released at mongoid_paranoia with an underscore.
