### PR TITLE
Ensure we find the correct Regexp::Raw class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 5.3.2 (Next)
+* [#240](https://github.com/mongoid/mongoid-slug/pull/240): Ensure we find the correct Regexp::Raw class - [@artfuldodger](https://github.com/artfuldodger).
 * Your contribution here.
 
 ## 5.3.1 (2017/04/03)

--- a/lib/mongoid/slug/unique_slug.rb
+++ b/lib/mongoid/slug/unique_slug.rb
@@ -130,7 +130,7 @@ module Mongoid
         if embedded? || Mongoid::Compatibility::Version.mongoid3? || Mongoid::Compatibility::Version.mongoid4?
           Regexp.new(escaped_pattern)
         else
-          Regexp::Raw.new(escaped_pattern)
+          BSON::Regexp::Raw.new(escaped_pattern)
         end
       end
 


### PR DESCRIPTION
With mongoid 5.2.1's addition of the `Origin::Extensions::Regexp::Raw` module,
the constant lookup was ambiguous.

Here's the exception I was seeing:
```
NoMethodError:
  undefined method `new' for Origin::Extensions::Regexp::Raw:Module
# /home/rof/cache/bundler/ruby/2.4.0/gems/mongoid-slug-5.3.2/lib/mongoid/slug/unique_slug.rb:133:in `regex_for_slug'
```