### PR TITLE
Remove deprecated alias_method_chain

### DIFF
--- a/lib/mongoid/slug/paranoia.rb
+++ b/lib/mongoid/slug/paranoia.rb
@@ -5,15 +5,15 @@ module Mongoid
     module Paranoia
       extend ActiveSupport::Concern
 
+      def restore
+        run_callbacks(:restore) do
+          super
+        end
+      end
+
       included do
         define_model_callbacks :restore
-
-        def restore_with_callbacks
-          run_callbacks(:restore) do
-            restore_without_callbacks
-          end
-        end
-        alias_method_chain :restore, :callbacks
+        self.class.prepend(Mongoid::Slug::Paranoia)
       end
     end
   end


### PR DESCRIPTION
Replace ```alias_method_chain``` with equivalent ```alias_method```. Fix #232 .