### PR TITLE
Ensure localized slug creates index on expected locale field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.3.4 (Next)
 
-* Your contribution here.
+* [#241](https://github.com/mongoid/mongoid-slug/pull/240): Fix: ensure localized slugs index expected localized slug fields - [@onomated](https://github.com/onomated)
 
 ## 5.3.3 (2017/04/06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.3.4 (Next)
 
-* [#241](https://github.com/mongoid/mongoid-slug/pull/240): Fix: ensure localized slugs index expected localized slug fields - [@onomated](https://github.com/onomated)
+* Your contribution here.
+* [#243](https://github.com/mongoid/mongoid-slug/pull/243): Fix: ensure localized slugs index expected localized slug fields - [@onomated](https://github.com/onomated).
 
 ## 5.3.3 (2017/04/06)
 

--- a/README.md
+++ b/README.md
@@ -284,10 +284,19 @@ class PageSlugLocalize
 end
 ```
 
-This feature is built upon Mongoid localized fields, so fallbacks and localization works as documented in the Mongoid manual.
-By specifying `localize: true`, the slug index will be created on the I18n::default_locale only.  You can specify all the locales
-you intend to support by providing a list of locales, for example `localize: [:en, :es, :de]`.  This will create a separate index
-for each locale listed.
+This feature is built upon Mongoid localized fields, so fallbacks and localization works as documented in the Mongoid manual.  By specifying `localize: true`, the slug index will be created on the default locale field only.  
+So with the [i18n.default_locale](http://guides.rubyonrails.org/i18n.html#the-public-i18n-api) set to `:en`, the index spec generated will be as follows:
+```ruby
+  index({ '_slugs.en' => 1 }, { unique: true, sparse: true })
+```
+_Scopes and index options may vary depending on other slug specifications_
+
+If you are supporting multiple locales, you can specify the list of locales to create indices on, for example `localize: [:en, :es, :de]`.  This will create a separate index for each locale supported:
+```ruby
+  index({ '_slugs.en' => 1 }, { unique: true, sparse: true })
+  index({ '_slugs.es' => 1 }, { unique: true, sparse: true })
+  index({ '_slugs.de' => 1 }, { unique: true, sparse: true })
+```
 
 ### Custom Find Strategies
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ end
 ```
 
 This feature is built upon Mongoid localized fields, so fallbacks and localization works as documented in the Mongoid manual.
+By specifying `localize: true`, the slug index will be created on the I18n::default_locale only.  You can specify all the locales
+you intend to support by providing a list of locales, for example `localize: [:en, :es, :de]`.  This will create a separate index
+for each locale listed.
 
 ### Custom Find Strategies
 

--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -87,7 +87,14 @@ module Mongoid
 
         # Set index
         unless embedded?
-          index(*Mongoid::Slug::Index.build_index(slug_scope_key, slug_by_model_type))
+          case options[:localize]
+          when true
+            index(*Mongoid::Slug::Index.build_index(slug_scope_key, slug_by_model_type, ::I18n.default_locale))
+          when Array
+            options[:localize].each { |locale| index(*Mongoid::Slug::Index.build_index(slug_scope_key, slug_by_model_type, locale)) }
+          else
+            index(*Mongoid::Slug::Index.build_index(slug_scope_key, slug_by_model_type))
+          end
         end
 
         self.slug_url_builder = block_given? ? block : default_slug_url_builder

--- a/lib/mongoid/slug/index.rb
+++ b/lib/mongoid/slug/index.rb
@@ -3,15 +3,20 @@ module Mongoid
     module Index
       # @param [ String or Symbol ] scope_key The optional scope key for the index
       # @param [ Boolean ] by_model_type Whether or not
+      # @param [ String or Symbol ] locale The locale for localized index field
       #
       # @return [ Array(Hash, Hash) ] the indexable fields and index options.
-      def self.build_index(scope_key = nil, by_model_type = false)
+      def self.build_index(scope_key = nil, by_model_type = false, locale = nil)
         # The order of field keys is intentional.
         # See: http://docs.mongodb.org/manual/core/index-compound/
         fields = {}
         fields[:_type] = 1       if by_model_type
         fields[scope_key] = 1 if scope_key
-        fields[:_slugs] = 1
+        if locale
+          fields["_slugs.#{locale}"] = 1
+        else
+          fields[:_slugs] = 1
+        end
 
         # By design, we use the unique index constraint when possible to enforce slug uniqueness.
         # When migrating legacy data to Mongoid slug, the _slugs field may be null on many records,

--- a/lib/mongoid/slug/version.rb
+++ b/lib/mongoid/slug/version.rb
@@ -1,5 +1,5 @@
 module Mongoid #:nodoc:
   module Slug
-    VERSION = '5.3.3'.freeze
+    VERSION = '5.3.4'.freeze
   end
 end

--- a/spec/mongoid/index_spec.rb
+++ b/spec/mongoid/index_spec.rb
@@ -1,10 +1,12 @@
 # encoding: utf-8
+
 require 'spec_helper'
 
 describe Mongoid::Slug::Index do
   let(:scope_key)     { nil }
   let(:by_model_type) { false }
-  subject { Mongoid::Slug::Index.build_index(scope_key, by_model_type) }
+  let(:locale) { nil }
+  subject { Mongoid::Slug::Index.build_index(scope_key, by_model_type, locale) }
 
   context 'when scope_key is set' do
     let(:scope_key) { :foo }
@@ -18,6 +20,16 @@ describe Mongoid::Slug::Index do
     context 'when by_model_type is false' do
       it { is_expected.to eq [{ _slugs: 1, foo: 1 }, {}] }
     end
+
+    context 'when locale is set' do
+      let(:locale) { :de }
+
+      it { is_expected.to eq [{ '_slugs.de' => 1, foo: 1 }, {}] }
+    end
+
+    context 'when locale is not set' do
+      it { is_expected.to eq [{ _slugs: 1, foo: 1 }, {}] }
+    end
   end
 
   context 'when scope_key is not set' do
@@ -29,6 +41,23 @@ describe Mongoid::Slug::Index do
 
     context 'when by_model_type is false' do
       it { is_expected.to eq [{ _slugs: 1 }, { unique: true, sparse: true }] }
+    end
+
+    context 'when locale is set' do
+      let(:locale) { :es }
+
+      it { is_expected.to eq [{ '_slugs.es' => 1 }, { unique: true, sparse: true }] }
+    end
+
+    context 'when locale is not set' do
+      it { is_expected.to eq [{ _slugs: 1 }, { unique: true, sparse: true }] }
+    end
+
+    context 'when locale is set and by_model_type is true' do
+      let(:locale) { :fr }
+      let(:by_model_type) { true }
+
+      it { is_expected.to eq [{ '_slugs.fr' => 1, _type: 1 }, {}] }
     end
   end
 end


### PR DESCRIPTION
Index for slug is created on default locale slug sub-field when "localize: true" is specified.  Otherwise, clients can specify a list of locales to create indices on.