### PR TITLE
Use Mongoid::Config.models to get the list of all available models in mongoid_slug.rake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.3.4 (Next)
 
-* Your contribution here.
+* [#251](https://github.com/mongoid/mongoid-slug/pull/251): Use Mongoid::Config.models to get the list of all available models in mongoid_slug.rake - [@syzspectroom](https://github.com/syzspectroom).
 
 ## 5.3.3 (2017/04/06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.3.4 (Next)
 
+* Your contribution here.
 * [#251](https://github.com/mongoid/mongoid-slug/pull/251): Use Mongoid::Config.models to get the list of all available models in mongoid_slug.rake - [@syzspectroom](https://github.com/syzspectroom).
 
 ## 5.3.3 (2017/04/06)

--- a/lib/tasks/mongoid_slug.rake
+++ b/lib/tasks/mongoid_slug.rake
@@ -1,12 +1,11 @@
+require 'byebug'
 namespace :mongoid_slug do
   desc 'Goes though all documents and sets slug if not already set'
   task set: :environment do |_, args|
     ::Rails.application.eager_load! if defined?(Rails)
-    klasses = Module.constants.find_all do |const|
-      next if const == :MissingSourceFile
-      const != const.upcase ? Mongoid::Slug > (Object.const_get const) : nil
+    klasses = Mongoid::Config.models.find_all do |const|
+      const.ancestors.include?(Mongoid::Slug)
     end
-    klasses.map! { |klass| klass.to_s.constantize }
     unless klasses.blank?
       models  = args.extras
       klasses = (klasses.map(&:to_s) & models.map(&:classify)).map(&:constantize) if models.any?

--- a/lib/tasks/mongoid_slug.rake
+++ b/lib/tasks/mongoid_slug.rake
@@ -1,4 +1,3 @@
-require 'byebug'
 namespace :mongoid_slug do
   desc 'Goes though all documents and sets slug if not already set'
   task set: :environment do |_, args|


### PR DESCRIPTION
this PR will fix #247.
My proposal is to use `Mongoid::Config.models` (https://www.rubydoc.info/github/mongoid/mongoid/Mongoid/Config#models-instance_method) to get the list of all available models instead of iterating through all `Module` constants and check if `Mongoid::Slug` is included in the model using `const.ancestors.include?(Mongoid::Slug)` which is much safer to use.
This fix will prevent the task from failing with errors like this: 
```
TypeError: compared with non class/module
```