### PR TITLE
#slug should not default to _id.to_s

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -248,8 +248,7 @@ module Mongoid
 
     # @return [String] the slug, or nil if the document does not have a slug.
     def slug
-      return _slugs.last if _slugs
-      _id.to_s
+      _slugs.last if _slugs
     end
 
     def slug_builder


### PR DESCRIPTION
`#slug` should not default to `_id.to_s`. This is inconsistent with the rest of the gem:

- `_slugs` does not contain `_id.to_s`
- `clear_slug!` sets `_slugs` to `[]`, so `#slug` will return `nil` in this case
- it will be overwritten when saving
- before saving, one would expect both `slug` and `_slugs` to be `nil`