### PR TITLE
Replace deprecated __find_args__ with Array#flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#277](https://github.com/mongoid/mongoid-slug/pull/277): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * [#274](https://github.com/mongoid/mongoid-slug/pull/274): Added support for scoping slugs by multiple fields - [@mikekosulin](https://github.com/mikekosulin).
+* [#XXX](https://github.com/mongoid/mongoid-slug/pull/XXX): Replace deprecated `__find_args__` with `Array#flatten` - [@samiFakhfakhScalingo](https://github.com/samiFakhfakhScalingo).
 * Your contribution here.
 
 ## 7.0.0 (2023/09/18)

--- a/lib/mongoid/slug/criteria.rb
+++ b/lib/mongoid/slug/criteria.rb
@@ -30,7 +30,7 @@ module Mongoid
       #
       # @return [ Array<Document>, Document ] The matching document(s).
       def find(*args)
-        look_like_slugs?(args.__find_args__) ? find_by_slug!(*args) : super
+        look_like_slugs?(args.flatten) ? find_by_slug!(*args) : super
       end
 
       # Find the matchind document(s) in the criteria for the provided slugs.
@@ -45,7 +45,7 @@ module Mongoid
       #
       # @return [ Array<Document>, Document ] The matching document(s).
       def find_by_slug!(*args)
-        slugs = args.__find_args__
+        slugs = args.flatten
         raise_invalid if slugs.any?(&:nil?)
         for_slugs(slugs).execute_or_raise_for_slugs(slugs, args.multi_arged?)
       end


### PR DESCRIPTION
__find_args__ is deprecated in Mongoid 9.x and will be removed in Mongoid 10.0
It's functionally equivalent to Array#flatten
This fixes the deprecation warning: DEPRECATION WARNING: __find_args__ is deprecated and will be removed from Mongoid 10.0